### PR TITLE
Add support for hard wrapped files.

### DIFF
--- a/edicat/__init__.py
+++ b/edicat/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (2018, 2, 3, "")
+VERSION = (2018, 4, 20, "")
 
 __version__ = "{0}.{1}.{2}{3}".format(*VERSION)


### PR DESCRIPTION
I encounted some EDI in the wild which hard wrap by inserting a CRLF `'\r\n'` every 80 characters.  This now handles them more gracefully.