### PR TITLE
BrokenPipeError fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 *.py[cod]
 dist/
 build/
+venv/

--- a/edicat/__init__.py
+++ b/edicat/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (2018, 4, 20, "")
+VERSION = (2018, 6, 25, "")
 
 __version__ = "{0}.{1}.{2}{3}".format(*VERSION)

--- a/edicat/__main__.py
+++ b/edicat/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 from typing import BinaryIO, Iterable, Iterator, Tuple
 
@@ -28,11 +29,14 @@ def openfiles(filenames: Iterable) -> Tuple[str, Iterator[BinaryIO]]:
 
 def output(filenames: Iterable, line_numbers: bool = False) -> int:
     ret_code = 0
-    for filename, file in openfiles(filenames):
-        lineno = 0
-        for line in readdocument(file, filename):
-            lprint(line, lineno, line_numbers)
-        ret_code = ret_code or int(lineno == 0)
+    try:
+        for filename, file in openfiles(filenames):
+            lineno = 0
+            for line in readdocument(file, filename):
+                lprint(line, lineno, line_numbers)
+            ret_code = ret_code or int(lineno == 0)
+    except BrokenPipeError:
+        sys.stdout = os.fdopen(1)  # suppress "Exception ignored in: [...]" when pager terminates.
     return ret_code
 
 


### PR DESCRIPTION
Suppress BrokenPipeError when output piped to pager (e.g. less) and pager is quit.

Previous behavior was to traceback.
```
Traceback (most recent call last):
  File "/usr/local/bin/edicat", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/edicat/__main__.py", line 53, in main
    sys.exit(output(args.filenames, args.lineno))
  File "/usr/local/lib/python3.6/dist-packages/edicat/__main__.py", line 34, in output
    lprint(line, lineno, line_numbers)
  File "/usr/local/lib/python3.6/dist-packages/edicat/__main__.py", line 14, in lprint
    print(line)
BrokenPipeError: [Errno 32] Broken pipe
```

Without the `sys.stdout` workaround, the following is printed by python 3.6 anyways:
```
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

Hence the ugly workaround.